### PR TITLE
Change server listen address to '0.0.0.0'

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,7 @@ import app from "./app.js";
 
 const PORT = process.env.PORT ?? 3000;
 
-const server: Server = app.listen(PORT, () => {
+const server: Server = app.listen(PORT, "0.0.0.0", () => {
   console.log(`Application is starting up. Would be available at port ${PORT}`);
 });
 


### PR DESCRIPTION
This pull request makes a small change to the server startup configuration, ensuring the application listens on all network interfaces rather than just the default.

* Updated the `app.listen` call in `src/server.ts` to bind the server to `"0.0.0.0"`, allowing external connections and not just localhost.