### PR TITLE
Convert PORT to a number for server initialization

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,7 @@ import app from "./app.js";
 
 const PORT = process.env.PORT ?? 3000;
 
-const server: Server = app.listen(PORT, () => {
+const server: Server = app.listen(Number(PORT), () => {
   console.log(`Application is starting up. Would be available at port ${PORT}`);
 });
 


### PR DESCRIPTION
This pull request makes a minor update to the server initialization logic to ensure the port value is always treated as a number.

* Server initialization: Changed the `app.listen` call in `src/server.ts` to explicitly convert the `PORT` environment variable to a number, preventing potential issues if `PORT` is provided as a string.